### PR TITLE
feat: Add support for Discord threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,51 @@
-# Duplicati + Discord Cloudflare Workers
+# Duplicati + Discord Cloudflare Worker
 
-If you want to send notifications from your (self-hosted) [Duplicati](https://duplicati.com/) instance to Discord, then you can deploy this Cloudflare worker to your Cloudflare account. It modifies the incoming Duplicati data and sends an embed message to a Discord webhook URL.
+If you want to send notifications from your (self-hosted) [Duplicati](https://duplicati.com/) instance to Discord, then you can deploy this [Cloudflare worker](https://developers.cloudflare.com/workers/) to your Cloudflare account. When called, it modifies the incoming Duplicati notification data and sends an embedded message to a Discord webhook URL.
 
 ## Instructions
 
+### 1. [Mostly automatic](https://developers.cloudflare.com/workers/platform/deploy-buttons/)
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/LekoArts/duplicati-discord-cloudflare-worker)
+
+### 2. Manual
+
 1. Clone this repository and install the dependencies with `pnpm install`
-1. Deploy this Cloudflare worker to your account by running `pnpm run deploy`
-1. Create a webhook URL for a given Discord channel
+1. Deploy the Cloudflare worker to your account by running `pnpm run deploy`
 
-   It will be in the following format:
+## Steps after worker is deployed
 
-   ```shell
-   https://discord.com/api/webhooks/123/abcdef
-   ```
+### 1. Get webhook URL for Discord channel
 
-   Copy the `123/abcdef` portion to your clipboard.
+[Create a webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) URL for a given Discord channel …
 
-1. Open your Duplicati dashboard and select **"Edit"** on the backup you wish to receive notifications for. Navigate to **"Options"** and under **"Advanced options"** click the three dots to **"Edit as text"**.
+- If you want to post to an ordinary channel, copy the default webhook URL as is. It will be in the following format: `https://discord.com/api/webhooks/123…/abcdef…`<br>
+  Copy the `123…/abcdef…` portion of the URL.
 
-   Add the `--send-http-json-urls` flag with your URL as following:
+- If you want to support [Discord threads](https://support.discord.com/hc/en-us/articles/4403205878423-Threads-FAQ), create a thread in Discord first. Then copy the link to it by right-clicking it and choose **Copy Link**.<br>The link will be in the form of `https://discord.com/channels/123…/987…`.
+  Extract the last part after the slash ('/'), i.e. `987…` - that's the thread id. Then append this `?thread_id=987…` string to the previously defined webhook URL.<br>
+  Copy the compounded string `123/abcdef?thread_id=987…` to your clipboard.
 
+### 2. Merge the Cloudflare worker URL with the copied string
+
+This should result in a string similar to `https://duplicati-discord-cloudflare-worker.<some_identifier>.workers.dev/123…/abcdef…`<br>
+Or, for threads: `https://duplicati-discord-cloudflare-worker.<some_identifier>.workers.dev/123…/abcdef…?thread_id=987…`
+
+### 3. Update Duplicati configuration
+   
+1. Open your Duplicati dashboard and select **Edit** on the backup you wish to receive notifications for.
+2. Navigate to **Options** and under **Advanced options** click the three dots to **Edit as text**.
+3. Add the `--send-http-json-urls` flag with your URL as following:
    ```text
-   --send-http-json-urls=https://url-to-your-worker.com/123/abcdef
+   --send-http-json-urls=https://url-to-your-worker.com/123…/abcdef…                    # for ordinary channels
+   
+   --send-http-json-urls=https://url-to-your-worker.com/123…/abcdef…?thread_id=987…     # for thread support
    ```
 
 1. Save the backup configuration. Run a backup and check if it's working.
+
+### 4. Set level for sending notifications (optional)
+To only receive notifications when a backup results in a warning or error, add this to the options as well (on a separate row)
+```
+--send-http-level=Warning,Error,Fatal
+```

--- a/README.md
+++ b/README.md
@@ -1,51 +1,55 @@
-# Duplicati + Discord Cloudflare Worker
+# Duplicati + Discord Cloudflare Workers
 
 If you want to send notifications from your (self-hosted) [Duplicati](https://duplicati.com/) instance to Discord, then you can deploy this [Cloudflare worker](https://developers.cloudflare.com/workers/) to your Cloudflare account. When called, it modifies the incoming Duplicati notification data and sends an embedded message to a Discord webhook URL.
 
-## Instructions
-
-### 1. [Mostly automatic](https://developers.cloudflare.com/workers/platform/deploy-buttons/)
-
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/LekoArts/duplicati-discord-cloudflare-worker)
 
-### 2. Manual
+## Instructions
 
-1. Clone this repository and install the dependencies with `pnpm install`
-1. Deploy the Cloudflare worker to your account by running `pnpm run deploy`
+1. Press the **Deploy to Cloudflare** button above and complete all steps. Make sure that the worker is successfully deployed.
+1. Create a [webhook URL](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) for a given Discord channel
 
-## Steps after worker is deployed
+   It will be in the following format:
 
-### 1. Get webhook URL for Discord channel
+   ```shell
+   https://discord.com/api/webhooks/123/abcdef
+   ```
 
-[Create a webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) URL for a given Discord channel …
+   Copy the `123/abcdef` portion to your clipboard.
 
-- If you want to post to an ordinary channel, copy the default webhook URL as is. It will be in the following format: `https://discord.com/api/webhooks/123…/abcdef…`<br>
-  Copy the `123…/abcdef…` portion of the URL.
+1. Open your Duplicati dashboard and select **"Edit"** on the backup you wish to receive notifications for. Navigate to **"Options"** and under **"Advanced options"** click the three dots to **"Edit as text"**.
 
-- If you want to support [Discord threads](https://support.discord.com/hc/en-us/articles/4403205878423-Threads-FAQ), create a thread in Discord first. Then copy the link to it by right-clicking it and choose **Copy Link**.<br>The link will be in the form of `https://discord.com/channels/123…/987…`.
-  Extract the last part after the slash ('/'), i.e. `987…` - that's the thread id. Then append this `?thread_id=987…` string to the previously defined webhook URL.<br>
-  Copy the compounded string `123/abcdef?thread_id=987…` to your clipboard.
+   Add the `--send-http-json-urls` flag with your URL as following:
 
-### 2. Merge the Cloudflare worker URL with the copied string
-
-This should result in a string similar to `https://duplicati-discord-cloudflare-worker.<some_identifier>.workers.dev/123…/abcdef…`<br>
-Or, for threads: `https://duplicati-discord-cloudflare-worker.<some_identifier>.workers.dev/123…/abcdef…?thread_id=987…`
-
-### 3. Update Duplicati configuration
-   
-1. Open your Duplicati dashboard and select **Edit** on the backup you wish to receive notifications for.
-2. Navigate to **Options** and under **Advanced options** click the three dots to **Edit as text**.
-3. Add the `--send-http-json-urls` flag with your URL as following:
    ```text
-   --send-http-json-urls=https://url-to-your-worker.com/123…/abcdef…                    # for ordinary channels
-   
-   --send-http-json-urls=https://url-to-your-worker.com/123…/abcdef…?thread_id=987…     # for thread support
+   --send-http-json-urls=https://url-to-your-worker.com/123/abcdef
    ```
 
 1. Save the backup configuration. Run a backup and check if it's working.
 
-### 4. Set level for sending notifications (optional)
-To only receive notifications when a backup results in a warning or error, add this to the options as well (on a separate row)
-```
+**Optional:** To only receive notifications when a backup results in a warning or error, add this under **"Advanced options"** as well (on a separate row):
+
+```text
 --send-http-level=Warning,Error,Fatal
 ```
+
+### Discord thread / forum channel
+
+If you want to send notifications to a [Discord thread](https://support.discord.com/hc/en-us/articles/4403205878423-Threads-FAQ) or to a post inside a [forum channel](https://support.discord.com/hc/en-us/articles/6208479917079-Forum-Channels-FAQ), you need to pass a `thread_id` to the Cloudflare worker. Here's how you can do that:
+
+1. Navigate to the thread / forum post, right-click it, and choose **"Copy Link"**.
+
+   It will be in the following format:
+
+   ```shell
+   https://discord.com/channels/123/456
+   ```
+
+   The `456` is your `thread_id`.
+
+1. Adjust the URL you're passing to the `--send-http-json-urls` flag by adding `?thread_id=<your-thread-id>` to the end of it:
+
+   ```diff
+   - --send-http-json-urls=https://url-to-your-worker.com/123/abcdef
+   + --send-http-json-urls=https://url-to-your-worker.com/123/abcdef?thread_id=456
+   ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,12 @@ app.get('/', (c) => {
 
 app.post('/:channel_id/:webhook_id', validator('json', (value) => value), async (c) => {
   const { channel_id, webhook_id } = c.req.param()
-  const discordWebhookUrl = `https://discord.com/api/webhooks/${channel_id}/${webhook_id}`
+  const thread_id = c.req.query('thread_id')
+  let discordWebhookUrl = `https://discord.com/api/webhooks/${channel_id}/${webhook_id}`
+
+  if (thread_id) {
+    discordWebhookUrl += `?thread_id=${encodeURIComponent(thread_id)}`
+  }
 
   const body = c.req.valid('json') as DuplicatiResponse
   const discordEmbed = createEmbed(body)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ app.post('/:channel_id/:webhook_id', validator('json', (value) => value), async 
   let discordWebhookUrl = `https://discord.com/api/webhooks/${channel_id}/${webhook_id}`
 
   if (thread_id) {
+    // See https://discord.com/developers/docs/resources/webhook#execute-webhook
     discordWebhookUrl += `?thread_id=${encodeURIComponent(thread_id)}`
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -43,4 +43,23 @@ describe('worker', () => {
     expect(res.status).toBe(200)
     expect(body).toEqual({ message: 'Discord webhook successfully triggered' })
   })
+  it('should handle thread_id request parameter', async () => {
+    fetchMock
+      .get('https://discord.com')
+      .intercept({ path: '/api/webhooks/channel/webhook-id?thread_id=123', method: 'POST' })
+      .reply(200)
+
+    const res = await app.request('/channel/webhook-id?thread_id=123', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(duplicatiSuccess),
+    }, env)
+
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ message: 'Discord webhook successfully triggered' })
+  })
 })


### PR DESCRIPTION
A new PR attempt to clear things up, I hope this works better. And again, sorry for all the mess – I realize I'm not too well-versed in git :P

Description:
A small code addition to support posting to Discord threads, i.e. in the form of https://discord.com/api/webhooks/1234567890/abcdefgh?thread_id=9876543210
Also added Deploy to Cloudflare button and made README.md more verbose and with some additional links.