### PR TITLE
Add Docker support and self-hosting docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.git
+.wrangler
+coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:25
+
+RUN npm install -g wrangler pnpm
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+CMD ["node", "--version"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Duplicati + Discord Cloudflare Workers
 
-If you want to send notifications from your (self-hosted) [Duplicati](https://duplicati.com/) instance to Discord, then you can deploy this [Cloudflare worker](https://developers.cloudflare.com/workers/) to your Cloudflare account. When called, it modifies the incoming Duplicati notification data and sends an embedded message to a Discord webhook URL.
+If you want to send notifications from your (self-hosted) [Duplicati](https://duplicati.com/) instance to Discord, then you can deploy this [Cloudflare worker](https://developers.cloudflare.com/workers/) to your Cloudflare account or self-host it using [Docker](#self-hosting-using-docker). When called, it modifies the incoming Duplicati notification data and sends an embedded message to a Discord webhook URL.
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/LekoArts/duplicati-discord-cloudflare-worker)
 
@@ -32,6 +32,15 @@ If you want to send notifications from your (self-hosted) [Duplicati](https://du
 ```text
 --send-http-level=Warning,Error,Fatal
 ```
+
+## Self-hosting using Docker
+**Requirements:**
+ - [Docker and Docker Compose installed](https://docs.docker.com/engine/install/)
+
+**Steps:**
+1. Clone this repository: `git clone https://github.com/LekoArts/duplicati-discord-cloudflare-worker.git`
+2. Change into the project directory: `cd duplicati-discord-cloudflare-worker`
+3. Start the service with Docker Compose: `docker compose up -d`
 
 ### Discord thread / forum channel
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    container_name: duplicati-discord-worker
+    build: .
+    command: ["wrangler", "dev", "--ip", "0.0.0.0", "--port", "8787", "--local-protocol", "http"]
+    ports:
+      - "8787:8787" # <Host Port>:<Container Port (do not change)>


### PR DESCRIPTION
Add Dockerfile and docker-compose.yml to enable running the Cloudflare worker locally in a container. Dockerfile uses node:25, installs wrangler and pnpm, installs dependencies from package.json/pnpm-lock.yaml, and copies the project into /app. docker-compose.yml defines a service that runs `wrangler dev` exposed on port 8787. Add .dockerignore to exclude node_modules, .git, .wrangler and coverage. Update README with concise self-hosting instructions using Docker Compose.